### PR TITLE
Adding Dockerfile for creating PokeBlazor image, fixes #6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Stage 1: Compile and publish the source code
+FROM microsoft/aspnetcore-build:2.1.300-preview1 AS builder
+WORKDIR /app
+COPY *.sln ./
+COPY PokeBlazor.Client ./PokeBlazor.Client
+COPY PokeBlazor.Server ./PokeBlazor.Server
+COPY PokeBlazor.Shared ./PokeBlazor.Shared
+RUN dotnet publish --configuration Release --output /app/out
+
+# Stage 2: Copies the published code out to published image
+FROM microsoft/aspnetcore-nightly:2.0.6
+WORKDIR /app
+
+COPY --from=builder /app/out .
+
+# Super hack to work around https://github.com/aspnet/Blazor/issues/376
+RUN mv -n wwwroot/* PokeBlazor.Client/dist
+RUN rm -rf wwwroot/
+
+ENTRYPOINT ["dotnet", "PokeBlazor.Server.dll"]

--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ If running from the command line, you will need to cd into the PokeBlazor.Server
 ``` shell
 dotnet run
 ```
+## Publishing
+A Dockerfile has been provided, so you can publish and run a container like so. The example below is accessible on http://localhost:8080
+``` docker build -t pokeblazor .
+docker run -p 8080:80 pokeblazor```


### PR DESCRIPTION
See README.md for notes on how to publish the container via Docker. (note, Docker requires image names be all lowercase, hence "pokeblazor" is the name)